### PR TITLE
Remove explicit :port in request-base-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ A treasure trove of Clojure goodness.
 
 ## License
 
-Copyright (c) 2015 Unbounce Marketing Solutions Inc.
+Copyright (c) 2015-2016 Unbounce Marketing Solutions Inc.
 
 Distributed under the MIT License.

--- a/project.clj
+++ b/project.clj
@@ -3,18 +3,18 @@
   :url "https://www.github.com/unbounce/treajure"
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"
-            :comments "Copyright (c) 2015 Unbounce Marketing Solutions Inc."}
+            :comments "Copyright (c) 2016 Unbounce Marketing Solutions Inc."}
 
   :profiles {:dev {:plugins [[lein-kibit "0.1.2"]
-                             [jonase/eastwood "0.2.1"]]
+                             [jonase/eastwood "0.2.3"]]
 
-                   :dependencies [[byte-streams "0.2.0"]
+                   :dependencies [[byte-streams "0.2.1"]
                                   [org.clojure/tools.logging "0.3.1"]
                                   [me.raynes/fs "1.4.6"]
-                                  [ring/ring-core "1.3.2"]
+                                  [ring/ring-core "1.4.0"]
                                   [cheshire "5.5.0"]
-                                  [ring/ring-jetty-adapter "1.3.2"]
-                                  [ring/ring-defaults "0.1.5"]
+                                  [ring/ring-jetty-adapter "1.4.0"]
+                                  [ring/ring-defaults "0.2.0"]
                                   [com.github.fge/json-schema-validator "2.2.6"]]
                    :resource-paths ["resources" "test-resources"]}
 
@@ -22,8 +22,8 @@
 
   :dependencies
   [
-   [org.clojure/clojure "1.7.0"]
-   [bwo/monads "0.2.0"]
+   [org.clojure/clojure "1.8.0"]
+   [bwo/monads "0.2.2"]
   ]
 
   :release-tasks [["vcs" "assert-committed"]

--- a/src/com/unbounce/treajure/map.clj
+++ b/src/com/unbounce/treajure/map.clj
@@ -6,3 +6,24 @@
   (if (every? map? vals)
     (apply merge-with deep-merge vals)
     (last vals)))
+
+(defn update-if-exists
+  "Variation of clojure.core/update-in which performs no-operation if the
+  key is not present in the map. "
+  [m keys f & args]
+  (let [value (get-in m keys ::not-found)]
+    (if-not (identical? value ::not-found)
+      (assoc-in m keys (apply f value args))
+      m)))
+
+(defn map-values
+  "Create a new map of same keys and applying f to all the values.
+
+  Taken from plumatic/plumbing.
+  "
+  [m f]
+  (cond
+    (sorted? m)
+    (reduce-kv (fn [out-m k v] (assoc out-m k (f v))) (sorted-map) m)
+    :otherwise
+    (persistent! (reduce-kv (fn [out-m k v] (assoc! out-m k (f v))) (transient {}) m))))

--- a/test/com/unbounce/treajure/map_test.clj
+++ b/test/com/unbounce/treajure/map_test.clj
@@ -16,3 +16,26 @@
                         :uno {:dos "dos"}
                         :eins "eins"
                         :other {:nested {:value :meh}}})))))
+
+(deftest update-if-exists-tests
+  (let [sample-object {:foo {:bar 0}}]
+    (testing "updates a nested object"
+      (is (= (update-if-exists sample-object
+               [:foo :bar] inc)
+             {:foo {:bar 1}})))
+    (testing "updates a nested object"
+      (is (= (update-if-exists sample-object
+               [:foo :bar] inc)
+             {:foo {:bar 1}})))
+    (testing "does not update a misisng key"
+      (is (= (update-if-exists sample-object [:foo :bar] + 3 4 5)
+             {:foo {:bar 12}})))))
+
+(deftest map-values-test
+  (testing "sorted map"
+    (is (= {:a 1 :b 1} (map-values (sorted-map :a 0 :b 0) inc)))
+    (is (sorted? (map-values (sorted-map :a 0 :b 0) inc))))
+  (testing "regular map"
+    (let [sample-object {:foo 2 :bar 3}]
+      (is (= (map-values sample-object inc)
+             {:foo 3 :bar 4})))))


### PR DESCRIPTION
This function is used for extracting the base URI of the original client request and generally for building URIs relative to the client's base URL. We should not explicitly set the :port unless the client specifies it as part of the `x-fowarded-host` or host headers.