### PR TITLE
Fix compatibility with Clojure 1.10 & Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ rubygems/
 .externalToolBuilders/
 *.log
 /bin/
+.eastwood

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: clojure
-
 script: lein do clean, kibit, eastwood, test, jar
+jdk:
+  - openjdk8
+  - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: clojure
-script: lein do clean, kibit, eastwood, test, jar
+script:
+  - lein with-profile dev,1.8  do clean, kibit, eastwood, test, jar
+  - lein with-profile dev,1.10 do clean, kibit, eastwood, test, jar
 jdk:
   - openjdk8
   - openjdk11

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ A treasure trove of Clojure goodness.
 
 ## License
 
-Copyright (c) 2015-2017 Unbounce Marketing Solutions Inc.
+Copyright (c) 2015-2020 Unbounce Marketing Solutions Inc.
 
 Distributed under the MIT License.

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://www.github.com/unbounce/treajure"
   :license {:name "The MIT License (MIT)"
             :url "http://opensource.org/licenses/MIT"
-            :comments "Copyright (c) 2015-2017 Unbounce Marketing Solutions Inc."}
+            :comments "Copyright (c) 2015-2020 Unbounce Marketing Solutions Inc."}
 
   :profiles {:dev {:plugins [[lein-kibit "0.1.2"]
                              [jonase/eastwood "0.2.3"]]

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,10 @@
    [org.clojure/clojure "1.10.1"]
    [bwo/monads "0.2.2"]
    [bwo/macroparser "0.0.7c"]
-  ]
+   [at.favre.lib/bytes "1.3.0"]
+   ]
+
+  :global-vars {*warn-on-reflection* true}
 
   :release-tasks [["vcs" "assert-committed"]
                   ["clean"]

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,8 @@
             :url "http://opensource.org/licenses/MIT"
             :comments "Copyright (c) 2015-2020 Unbounce Marketing Solutions Inc."}
 
-  :profiles {:dev {:plugins [[lein-kibit "0.1.2"]
-                             [jonase/eastwood "0.2.3"]]
+  :profiles {:dev {:plugins [[lein-kibit "0.1.8"]
+                             [jonase/eastwood "0.3.6"]]
 
                    :dependencies [[byte-streams "0.2.4"]
                                   [org.clojure/tools.logging "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,10 @@
             :url "http://opensource.org/licenses/MIT"
             :comments "Copyright (c) 2015-2020 Unbounce Marketing Solutions Inc."}
 
-  :profiles {:dev {:plugins [[lein-kibit "0.1.8"]
+  :profiles {:1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.10 {:dependecies  [[org.clojure/clojure "1.10.1"]]}
+
+             :dev {:plugins [[lein-kibit "0.1.8"]
                              [jonase/eastwood "0.3.6"]]
 
                    :dependencies [[byte-streams "0.2.4"]

--- a/project.clj
+++ b/project.clj
@@ -8,13 +8,13 @@
   :profiles {:dev {:plugins [[lein-kibit "0.1.2"]
                              [jonase/eastwood "0.2.3"]]
 
-                   :dependencies [[byte-streams "0.2.2"]
-                                  [org.clojure/tools.logging "0.3.1"]
+                   :dependencies [[byte-streams "0.2.4"]
+                                  [org.clojure/tools.logging "1.1.0"]
                                   [me.raynes/fs "1.4.6"]
-                                  [ring/ring-core "1.6.0"]
-                                  [cheshire "5.7.1"]
-                                  [ring/ring-jetty-adapter "1.6.0"]
-                                  [ring/ring-defaults "0.3.0"]
+                                  [ring/ring-core "1.8.1"]
+                                  [cheshire "5.10.0"]
+                                  [ring/ring-jetty-adapter "1.8.1"]
+                                  [ring/ring-defaults "0.3.2"]
                                   [com.github.fge/json-schema-validator "2.2.6"]]
                    :resource-paths ["resources" "test-resources"]}
 
@@ -22,8 +22,9 @@
 
   :dependencies
   [
-   [org.clojure/clojure "1.8.0"]
+   [org.clojure/clojure "1.10.1"]
    [bwo/monads "0.2.2"]
+   [bwo/macroparser "0.0.7c"]
   ]
 
   :release-tasks [["vcs" "assert-committed"]

--- a/src/com/unbounce/treajure/io.clj
+++ b/src/com/unbounce/treajure/io.clj
@@ -15,9 +15,9 @@
   "Creates a java.io.OutputStream that acculates bytes until the specified character is met or until close are called.
    When one of these events occur, it emits the accumulated bytes to the provided function. An additional function
    can optionally be provided to be called after the OutputStream has been closed."
-  ([split-char emit-fn]
+  (^OutputStream [split-char emit-fn]
    (split-emit-output-stream split-char emit-fn (fn [])))
-  ([split-char emit-fn close-fn]
+  (^OutputStream [split-char emit-fn close-fn]
     {:pre  [(char? split-char)
             (fn? emit-fn)]
      :post [(instance? OutputStream %)]}

--- a/src/com/unbounce/treajure/monad.clj
+++ b/src/com/unbounce/treajure/monad.clj
@@ -1,5 +1,5 @@
 (ns com.unbounce.treajure.monad
-  (:refer-clojure :hide [do])
+  (:refer-clojure :exclude [do])
   (:require [monads.core :refer [>>=] :as monads])
   (:import [monads.types Bind Return]))
 

--- a/src/com/unbounce/treajure/rails.clj
+++ b/src/com/unbounce/treajure/rails.clj
@@ -4,14 +4,14 @@
            java.util.Collections
            javax.crypto.Mac
            javax.crypto.spec.SecretKeySpec
-           javax.xml.bind.DatatypeConverter))
+           at.favre.lib.bytes.Bytes))
 
 (defonce ^:private encoding "US-ASCII")
 (defonce ^:private algorithm "HmacSHA1")
 
 (defn- string->bytes
-  [s]
-  (.getBytes s encoding))
+  [^String s]
+  (.getBytes s ^String encoding))
 
 (defonce ^:private user-id-field-marker
   (seq
@@ -28,12 +28,12 @@
         algorithm))))
 
 (defn- bytes->hex-string
-  [bs]
-  (DatatypeConverter/printHexBinary bs))
+  [^"[B" bs]
+  (.encodeHex (Bytes/wrap bs)))
 
 (defn- b64-string->bytes
-  [b64-string]
-  (DatatypeConverter/parseBase64Binary b64-string))
+  [^String b64-string]
+  (.array (Bytes/parseBase64 b64-string)))
 
 (defn- aindex-of
   [haystack needle]

--- a/test/com/unbounce/treajure/json/schema_test.clj
+++ b/test/com/unbounce/treajure/json/schema_test.clj
@@ -206,7 +206,7 @@
                       ".json")
         _ (spit schema-file schema-str)
         schema (.getJsonSchema
-                 json-schema-factory
+                 ^JsonSchemaFactory json-schema-factory
                  (str (.toURI schema-file)))]
 
     (is (.validInstanceUnchecked

--- a/test/com/unbounce/treajure/ring_test.clj
+++ b/test/com/unbounce/treajure/ring_test.clj
@@ -7,7 +7,7 @@
 (def ^:dynamic *test-file* nil)
 
 (defonce ^:private test-file-contents "this is a test file")
-(defonce ^:private test-stream-contents "streamed data")
+(defonce ^:private ^String test-stream-contents "streamed data")
 
 (defn- with-app [f]
   (let [test-file (fs/temp-file "treajure" "test")]
@@ -74,7 +74,7 @@
     (tring/strip-charset "text/html; charset=UTF-16") "text/html"))
 
 (defn- bytes-seq [e]
-  (when e (seq (.getBytes e))))
+  (when e (seq (.getBytes ^String e))))
 
 (deftest request-bytes
   (with-open [r (io/input-stream (.getBytes test-stream-contents))]


### PR DESCRIPTION
This PR contains several small changes:

1. Removes an invalid call to `:refer-clojure`
2. Upgrade Dependencies
3. Replace dependency on `javax.xml.DataTypeConverter` to ensure library works seamlessly with Java 8/11.
